### PR TITLE
Depend bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "asar": "^0.14.3",
+    "cross-spawn-promise": "^0.10.1",
     "debug": "^3.1.0",
     "fs-extra": "^5.0.0",
-    "glob": "^7.1.2",
     "glob-promise": "^3.4.0",
     "lodash": "^4.17.5",
     "nodeify": "^1.0.1",
@@ -41,7 +41,6 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "cross-spawn-promise": "^0.10.1",
     "eslint": "^4.18.2",
     "eslint-config-standard": "11.0.0",
     "eslint-plugin-import": "^2.9.0",
@@ -52,7 +51,6 @@
     "http-promise": "^0.1.4",
     "mocha": "^5.0.4",
     "promise-retry": "^1.1.1",
-    "rimraf": "^2.6.2",
     "serve-static": "^1.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-windows",
   "description": "Create a Windows package for your Electron app.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",


### PR DESCRIPTION
I overlook that the module `cross-spawn-promise` was listed only as `devDependencies` which causes errors. This wasn't reported by the tests because `devDependencies` are always installed when testing.

This PR fixes the issue and also release a new patch version.