### PR TITLE
License url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-installer-windows",
   "description": "Create a Windows package for your Electron app.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "author": {
     "name": "Daniel Perez Alvarez",

--- a/resources/spec.ejs
+++ b/resources/spec.ejs
@@ -11,7 +11,7 @@
     <% if (owners && owners.length) { %><owners><%- owners.join(', ') %></owners><% } %>
     <% if (homepage) { %><projectUrl><%- homepage %></projectUrl><% } %>
     <% if (iconUrl) { %><iconUrl><%- iconUrl %></iconUrl><% } %>
-    <% if (licenseUrl) { %><licenseUrl><%- licenseUrl %></iconUrl><% } %>
+    <% if (licenseUrl) { %><licenseUrl><%- licenseUrl %></licenseUrl><% } %>
     <% if (requireLicenseAcceptance) { %><requireLicenseAcceptance><%- requireLicenseAcceptance %></requireLicenseAcceptance><% } %>
     <% if (tags && tags.length) { %><tags><%- tags.join(' ') %></tags><% } %>
   </metadata>


### PR DESCRIPTION
It seems that the spec file had a mismatched tag for `licenseUrl`, this bug has been in the code since the first commit.
It also releases a new patch version